### PR TITLE
Implement OP_CHECKSIGADD opcode

### DIFF
--- a/ui/OpCodeParser/OpFunctions.tsx
+++ b/ui/OpCodeParser/OpFunctions.tsx
@@ -361,6 +361,57 @@ export const opFunctions: { [key: string]: Function } = {
       error: null,
     }
   },
+  OP_CHECKSIGADD: (stack: StackType) => {
+    if (!stack) return null
+    if (stack?.length < 3) {
+      return {
+        value: null,
+        error: 'OP_CHECKSIGADD requires 3 items on the stack',
+      }
+    }
+    const pubkey = stack.pop()
+    const n = Number(stack.pop())
+    const sig = stack.pop()
+
+    if (!Number.isInteger(n)) {
+      return {
+        value: null,
+        error: `OP_CHECKSIGADD: invalid counter value: ${n}`,
+      }
+    }
+
+    const key = getKey(pubkey)?.value?.toUpperCase()
+    const sigVal = getSig(sig)?.value?.toUpperCase()
+
+    if (!key) {
+      return {
+        value: null,
+        error: 'OP_CHECKSIGADD: invalid public key',
+      }
+    }
+
+    // If signature is empty, push n unchanged
+    if (!sig || sig === '' || sig === 0 || sig === '0') {
+      return {
+        value: n,
+        error: null,
+      }
+    }
+
+    if (!sigVal) {
+      return {
+        value: null,
+        error: `OP_CHECKSIGADD: invalid signature: ${sig}`,
+      }
+    }
+
+    // If signature matches pubkey, push n + 1; otherwise push n
+    const valid = key === sigVal
+    return {
+      value: valid ? n + 1 : n,
+      error: null,
+    }
+  },
   OP_CHECKMULTISIG: (stack: StackType) => {
     if (!stack) return null
     if (stack?.length < 1) {
@@ -627,6 +678,7 @@ export const OpCodeTypes = {
   OP_HASH160: 'crypto',
   OP_HASH256: 'crypto',
   OP_CHECKSIG: 'crypto',
+  OP_CHECKSIGADD: 'crypto',
   OP_CHECKMULTISIG: 'crypto',
 
   OP_EQUAL: 'bitwise',
@@ -684,6 +736,7 @@ export const OpCodeHex = {
   OP_HASH256: 'aa',
   OP_CHECKSIG: 'ac',
   OP_CHECKMULTISIG: 'ae',
+  OP_CHECKSIGADD: 'ba',
 
   OP_EQUAL: '87',
   OP_EQUALVERIFY: '88',

--- a/ui/OpCodeParser/OpFunctions.tsx
+++ b/ui/OpCodeParser/OpFunctions.tsx
@@ -377,7 +377,7 @@ export const opFunctions: { [key: string]: Function } = {
     if (!Number.isInteger(n)) {
       return {
         value: null,
-        error: `OP_CHECKSIGADD: invalid counter value: ${n}`,
+        error: `OP_CHECKSIGADD: requires second value to be an unsigned integer`,
       }
     }
 
@@ -414,7 +414,7 @@ export const opFunctions: { [key: string]: Function } = {
     if (key !== sigVal) {
       return {
         value: null,
-        error: `OP_CHECKSIGADD: non-empty signature failed verification (NULLFAIL)`,
+        error: `OP_CHECKSIGADD: non-empty signature failed verification`,
       }
     }
 

--- a/ui/OpCodeParser/OpFunctions.tsx
+++ b/ui/OpCodeParser/OpFunctions.tsx
@@ -369,6 +369,7 @@ export const opFunctions: { [key: string]: Function } = {
         error: 'OP_CHECKSIGADD requires 3 items on the stack',
       }
     }
+
     const pubkey = stack.pop()
     const n = Number(stack.pop())
     const sig = stack.pop()
@@ -380,17 +381,21 @@ export const opFunctions: { [key: string]: Function } = {
       }
     }
 
-    const key = getKey(pubkey)?.value?.toUpperCase()
-    const sigVal = getSig(sig)?.value?.toUpperCase()
-
-    if (!key) {
+    if (n < 0) {
       return {
         value: null,
-        error: 'OP_CHECKSIGADD: invalid public key',
+        error: `OP_CHECKSIGADD: counter n must be non-negative, got: ${n}`,
       }
     }
 
-    // If signature is empty, push n unchanged
+    const key = getKey(pubkey)?.value?.toUpperCase()
+    if (!key) {
+      return {
+        value: null,
+        error: `OP_CHECKSIGADD: invalid public key: ${pubkey}`,
+      }
+    }
+
     if (!sig || sig === '' || sig === 0 || sig === '0') {
       return {
         value: n,
@@ -398,17 +403,23 @@ export const opFunctions: { [key: string]: Function } = {
       }
     }
 
+    const sigVal = getSig(sig)?.value?.toUpperCase()
     if (!sigVal) {
       return {
         value: null,
-        error: `OP_CHECKSIGADD: invalid signature: ${sig}`,
+        error: `OP_CHECKSIGADD: invalid signature format: ${sig}`,
       }
     }
 
-    // If signature matches pubkey, push n + 1; otherwise push n
-    const valid = key === sigVal
+    if (key !== sigVal) {
+      return {
+        value: null,
+        error: `OP_CHECKSIGADD: non-empty signature failed verification (NULLFAIL)`,
+      }
+    }
+
     return {
-      value: valid ? n + 1 : n,
+      value: n + 1,
       error: null,
     }
   },

--- a/ui/OpCodeParser/OpFunctions.tsx
+++ b/ui/OpCodeParser/OpFunctions.tsx
@@ -377,14 +377,14 @@ export const opFunctions: { [key: string]: Function } = {
     if (!Number.isInteger(n)) {
       return {
         value: null,
-        error: `OP_CHECKSIGADD: requires second value to be an unsigned integer`,
+        error: `OP_CHECKSIGADD: requires second value to be an integer`,
       }
     }
 
-    if (n < 0) {
+    if (n < -2147483648 || n > 2147483647) {
       return {
         value: null,
-        error: `OP_CHECKSIGADD: counter n must be non-negative, got: ${n}`,
+        error: `OP_CHECKSIGADD: counter n must be within 4 bytes, got: ${n}`,
       }
     }
 

--- a/ui/OpCodeParser/OpRunner.tsx
+++ b/ui/OpCodeParser/OpRunner.tsx
@@ -50,6 +50,27 @@ const getRelationsSourceForOperation = (
           style: arrowLineStyles,
         },
       ]
+    case 'OP_CHECKSIGADD':
+      return [
+        {
+          targetId: `item${currentIndex}-0`,
+          sourceAnchor: 'left',
+          targetAnchor: 'right',
+          style: arrowLineStyles,
+        },
+        {
+          targetId: `item${currentIndex}-1`,
+          sourceAnchor: 'left',
+          targetAnchor: 'right',
+          style: arrowLineStyles,
+        },
+        {
+          targetId: `item${currentIndex}-2`,
+          sourceAnchor: 'left',
+          targetAnchor: 'right',
+          style: arrowLineStyles,
+        },
+      ]
     case 'OP_DUP':
     case 'OP_SIZE':
     case 'OP_SHA256':
@@ -128,6 +149,7 @@ const getRelationsTargetForOperations = (operation: string): Number[] => {
     case 'OP_HASH160':
     case 'OP_HASH256':
     case 'OP_CHECKSIG':
+    case 'OP_CHECKSIGADD':
     case 'OP_CHECKMULTISIG':
       return [0]
     case 'OP_DUP':


### PR DESCRIPTION
# Summary
Implements OP_CHECKSIGADD, the tapscript replacement for OP_CHECKMULTISIG (BIP-342). The opcode enables k-of-n multisig via script composition rather than a single monolithic opcode, eliminating the legacy dummy-element bug and enforcing NULLFAIL at the consensus level. This change is valuable for visualizing Taproot scripts which are incompatible with OP_CHECKMULTISIG.

## Changes
1. OpFunctions.tsx
- Correct pop order: `pubkey → n → sig` (top-to-bottom per BIP-342)
- NULLFAIL enforcement: a non-empty sig that fails verification aborts the script with error

3. OpRunner.tsx
- 3-item arrow relations for OP_CHECKSIGADD (pubkey, n, sig)
- Result target [0] registered in getRelationsTargetForOperations
- Opcode type registered as crypto in OpCodeTypes
- Hex value 0xba registered in OpCodeHex

## Testing
- OP_0 <sig(A)> <pubkey(A)>  →  should push 1
- OP_0 <sig(A)> <pubkey(B)>  →  should FAIL (NULLFAIL)
- OP_0 OP_0 <pubkey(A)>       →  should push 0 (empty sig, no match)
- k-of-n: chain N calls, compare final counter to k with OP_NUMEQUAL